### PR TITLE
Use alias imports instead of relative path imports

### DIFF
--- a/lib/src/ui/components.ts
+++ b/lib/src/ui/components.ts
@@ -1,6 +1,6 @@
 import { Page } from '@playwright/test';
-import { NavBar } from './components/navBar';
-import { StaffBar } from './components/staffBar';
+import { NavBar } from '@ui/components/navBar';
+import { StaffBar } from '@ui/components/staffBar';
 
 export class Components {
   constructor(private readonly page: Page) {}

--- a/lib/src/ui/pages.ts
+++ b/lib/src/ui/pages.ts
@@ -1,6 +1,6 @@
 import { Page } from '@playwright/test';
-import { Home } from './pages/home';
-import { LogIn } from './pages/login';
+import { Home } from '@ui/pages/home';
+import { LogIn } from '@ui/pages/login';
 
 export class Pages {
   constructor(private readonly page: Page) {}

--- a/lib/src/ui/ui.ts
+++ b/lib/src/ui/ui.ts
@@ -1,6 +1,6 @@
 import { Page } from '@playwright/test';
-import { Pages } from './pages';
-import { Components } from './components';
+import { Pages } from '@ui/pages';
+import { Components } from '@ui/components';
 
 export class UI {
   constructor(private readonly page: Page) {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "playwright-starter-project-typescript",
+  "name": "playwright-typescript-xenforo",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "playwright-starter-project-typescript",
+      "name": "playwright-typescript-xenforo",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
@@ -22,6 +22,7 @@
         "prettier": "^3.2.5",
         "pretty-quick": "^4.0.0",
         "ts-node": "^10.9.2",
+        "tsc-alias": "^1.8.10",
         "typescript": "^5.5.4",
         "typescript-eslint": "^7.18.0"
       }
@@ -588,6 +589,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -614,6 +628,18 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -659,6 +685,42 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cli-cursor": {
@@ -1427,6 +1489,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1799,11 +1873,33 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -2011,6 +2107,18 @@
         "node": ">=16"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2199,6 +2307,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2218,6 +2335,18 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2598,6 +2727,32 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsc-alias": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.10.tgz",
+      "integrity": "sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -1,26 +1,28 @@
 {
-  "name": "playwright-starter-project-typescript",
+  "name": "playwright-typescript-xenforo",
   "version": "1.0.0",
-  "description": "Starter project for Playwright using TypeScript.  Includes eslint, prettier, and husky pre-commit hooks for staged files.",
+  "description": "Playwright automation project with typescript to demonstrate tests against xenForo forum software",
   "keywords": [],
   "author": "Andy Gleed aka Automation Andy - andy@automationandy.net",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Automation-Andy/playwright-starter-project-typescript"
+    "url": "https://github.com/Automation-Andy/Playwright-Typescript-xenForo"
   },
   "main": "index.js",
   "scripts": {
     "test": "playwright test",
+    "start": "ts-node -r tsconfig-paths/register",
     "tsc": "tsc --pretty --noEmit",
+    "build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
     "lint": "eslint --max-warnings=0 --fix **/*.ts",
     "pretty-quick": "pretty-quick",
-    "lint-staged": "lint-staged",
+    "lint-staged": "lint-staged -r",
     "prepare": "husky"
   },
   "lint-staged": {
     "**/*.ts": [
-      "npm run tsc",
+      "npm run build",
       "npm run lint",
       "npm run pretty-quick"
     ]
@@ -39,6 +41,7 @@
     "prettier": "^3.2.5",
     "pretty-quick": "^4.0.0",
     "ts-node": "^10.9.2",
+    "tsc-alias": "^1.8.10",
     "typescript": "^5.5.4",
     "typescript-eslint": "^7.18.0"
   }

--- a/tests/fixtures/base.ts
+++ b/tests/fixtures/base.ts
@@ -1,6 +1,6 @@
 import { test as base } from '@playwright/test';
-import { Users } from '../../lib/data/users';
-import { UI } from '../../lib/src/ui/ui';
+import { Users } from '@data/users';
+import { UI } from '@ui/ui';
 
 type MyFixtures = {
   ui: UI;

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from './fixtures/base';
-import { User } from '../lib/src/enums/users';
+import { test, expect } from '@fixtures/base';
+import { User } from '@enums/users';
 
 test(`Log in with registered user by username and password`, async ({
   users,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,14 +28,15 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "Node" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    // "baseUrl": "." /* Specify the base directory to resolve non-relative module names. */,
-    // "paths": {
-    //   "@ui/*": ["lib/src/ui/*"],
-    //   "@interfaces/*": ["lib/src/interfaces/*"],
-    //   "@enums/*": ["lib/src/enums/*"],
-    //   "@fixtures/*": ["tests/fixtures/*"],
-    //   "@data/*": ["lib/data/*"]
-    // } /* Specify a set of entries that re-map imports to additional lookup locations. */,
+    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
+    "paths": {
+      "@ui/*": ["lib/src/ui/*"],
+      "@interfaces/*": ["lib/src/interfaces/*"],
+      "@enums/*": ["lib/src/enums/*"],
+      "@fixtures/*": ["tests/fixtures/*"],
+      "@data/*": ["lib/data/*"],
+      "@tests/*": ["tests/*"]
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
@@ -61,7 +62,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./build" /* Specify an output folder for all emitted files. */,
+    "outDir": "./build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -113,5 +114,8 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": ["lib/**/*", "tests/**/*", "global"],
-  "exclude": ["node_modules", "build"]
+  "exclude": ["node_modules", "build"],
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
 }


### PR DESCRIPTION
Changed using relative imports to alias imports for improved readability and easier refactoring.

- installed package tsc-alias
- added build script `"build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json"` to package.json
- called that from lint-staged which is called automatically in the pre-commit hook using husky

Switched all relevent files to alias imports as set in tsconfig.json